### PR TITLE
Add -w/--warning and -c/--critical args

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Nagios plugin for monitoring [ClamAV] virus scans.
 
-Exits `CRITICAL` if any infected files are reported within the `clamscan` log, otherwise `OK`.
-
 ## Installation
 
 Install [ClamAV].
@@ -30,23 +28,33 @@ define command {
 ## Usage
 
 ```
-Usage: ./check_clamav -l <path>
+Usage: ./check_clamav -l <path> [options]
 ```
 
 ### Examples
 
 ```sh
-# exit CRITICAL if 1 or more infected files are found, otherwise OK
+# exit OK if 0 infected files detected, CRITICAL if 1 or more detected
 ./check_clamav -l /tmp/clamav.log
+
+# exit OK if 0 infected files detected, WARNING if upto 10 detected, CRITICAL if 10 or more detected
+./check_clamav -l /tmp/clamav.log -c 10
+
+# exit OK if upto 4 infected files detected, WARNING if upto 5 detected, CRITICAL if 10 or more detected
+./check_clamav -l /tmp/clamav.log -c 10 -w 5
 ```
 
 ### Options
 
 ```
 -l, --logfile <path>        Path to clamscan logfile
+-w, --warning <number>      number of infected files treat as WARNING
+-c, --critical <number>     number of infected files to treat as CRITICAL
 -V, --version               output version
 -h, --help                  output help information
 ```
+
+`-c`/`--critical` takes priority over `-w`/`--warning`.
 
 ## Dependencies
 

--- a/check_clamav
+++ b/check_clamav
@@ -13,6 +13,8 @@ OK=0
 WARNING=1
 CRITICAL=2
 UNKNOWN=3
+CRITICAL_THRESHOLD=1
+WARNING_THRESHOLD=1
 
 #
 # Output version.
@@ -27,7 +29,7 @@ version() {
 #
 
 usage() {
-  echo 'Usage: ./check_clamav -l <path>'
+  echo 'Usage: ./check_clamav -l <path> [options]'
 }
 
 #
@@ -41,10 +43,18 @@ help() {
   Examples:
     ./check_clamav -l /tmp/clamav.log
 
+    ./check_clamav -l /tmp/clamav.log -c 10
+
+    ./check_clamav -l /tmp/clamav.log -c 10 -w 5
+
   Options:
     -l, --logfile <path>        Path to clamscan logfile
+    -w, --warning <number>      number of infected files treat as WARNING
+    -c, --critical <number>     number of infected files to treat as CRITICAL
     -V, --version               output version
     -h, --help                  output help information
+
+  -c/--critical takes priority over -w/--warning.
 
   For more information, see https://github.com/tommarshall/nagios-check-clamav
 
@@ -59,6 +69,8 @@ while test $# -ne 0; do
   ARG=$1; shift
   case $ARG in
     -l|--logfile) LOGFILE_PATH=$1; shift ;;
+    -w|--warning) WARNING_THRESHOLD=$1; shift ;;
+    -c|--critical) CRITICAL_THRESHOLD=$1; shift ;;
     -V|--version) version; exit ;;
     -h|--help) help; exit ;;
     *)
@@ -103,9 +115,13 @@ fi
 # report and exit
 #
 
-if [ "$INFECTED_FILES_COUNT" -lt "1" ]; then
-  echo "OK: ${INFECTED_FILES_COUNT} infected file(s) detected"
-  exit $OK
+if [ "$INFECTED_FILES_COUNT" -lt "$CRITICAL_THRESHOLD" ]; then
+  if [ "$INFECTED_FILES_COUNT" -lt "$WARNING_THRESHOLD" ]; then
+    echo "OK: ${INFECTED_FILES_COUNT} infected file(s) detected"
+    exit $OK
+  fi
+  echo "WARNING: ${INFECTED_FILES_COUNT} infected file(s) detected"
+  exit $WARNING
 fi
 
 echo "CRITICAL: ${INFECTED_FILES_COUNT} infected file(s) detected"

--- a/test/check_clamav.bats
+++ b/test/check_clamav.bats
@@ -112,6 +112,109 @@ EOF
   assert_output "OK: 0 infected file(s) detected"
 }
 
+# --critical
+# ------------------------------------------------------------------------------
+@test "--critical overrides default" {
+  cat > clamav.log.infected <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 1
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 2
+
+  assert_failure 1
+  assert_output "WARNING: 1 infected file(s) detected"
+}
+
+@test "-c is an alias for --critical" {
+  cat > clamav.log.infected <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 1
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.infected -c 2
+
+  assert_failure 1
+  assert_output "WARNING: 1 infected file(s) detected"
+}
+
+# --warning
+# ------------------------------------------------------------------------------
+@test "--warning overrides default" {
+  cat > clamav.log.infected <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 1
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 3 --warning 2
+
+  assert_success
+  assert_output "OK: 1 infected file(s) detected"
+}
+
+@test "-w is an alias for --warning" {
+  skip
+}
+
+@test "-w is an alias for --warning" {
+  cat > clamav.log.infected <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 1
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 3 -w 2
+
+  assert_success
+  assert_output "OK: 1 infected file(s) detected"
+}
+
+@test "critical takes prescence over warning" {
+cat > clamav.log.infected <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 2
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 2 --warning 1
+
+  assert_failure 2
+  assert_output "CRITICAL: 2 infected file(s) detected"
+}
+
 # --version
 # ------------------------------------------------------------------------------
 @test "--version prints the version" {
@@ -134,12 +237,12 @@ EOF
   run $BASE_DIR/check_clamav --help
 
   assert_success
-  assert_line --partial "Usage: ./check_clamav -l <path>"
+  assert_line --partial "Usage: ./check_clamav -l <path> [options]"
 }
 
 @test "-h is an alias for --help" {
   run $BASE_DIR/check_clamav -h
 
   assert_success
-  assert_line --partial "Usage: ./check_clamav -l <path>"
+  assert_line --partial "Usage: ./check_clamav -l <path> [options]"
 }


### PR DESCRIPTION
**Because:**

* The default is to treat the presence of any infected file as a
  `CRITICAL`.
* That's sensible, but it's good practise to have the ability to
  control when a nagios plugin issues a `WARNING` or `CRITICAL`.