### PR TITLE
Ensure executable dependencies are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Usage: ./check_clamav -l <path> [options]
 ## Dependencies
 
 * Bash
+* `cut`, `grep`, `rev`, `sed`
 
 [ClamAV]: https://www.clamav.net/
 [check_clamav]: https://cdn.rawgit.com/tommarshall/nagios-check-clamav/v0.1.0/check_clamav

--- a/check_clamav
+++ b/check_clamav
@@ -85,6 +85,14 @@ done
 # Showtime.
 #
 
+# ensure we have executable dependencies
+for dependency in cut grep rev sed; do
+  if ! hash $dependency >/dev/null 2>&1; then
+    echo "UNKNOWN: Missing dependency: ${dependency}"
+    exit $UNKNOWN
+  fi
+done
+
 # ensure we have a LOGFILE_PATH
 if [ -z "$LOGFILE_PATH" ]; then
   echo 'UNKNOWN: --logfile/-l not set'

--- a/test/check_clamav.bats
+++ b/test/check_clamav.bats
@@ -58,6 +58,14 @@ EOF
   assert_output "UNKNOWN: Unable to locate infected files count within scan summary"
 }
 
+@test "exits UNKNOWN if an executable dependency is missing" {
+  PATH='/bin'
+  run $BASE_DIR/check_clamav --logfile clamav.log
+
+  assert_failure 3
+  assert_output "UNKNOWN: Missing dependency: cut"
+}
+
 # Defaults
 #------------------------------------------------------------------------------
 @test "exits OK if no infected files are found" {


### PR DESCRIPTION
**Because:**

* The check expects a number of executables to be present on the `PATH`.
* If they're not available then the check may not behave correctly,
  therefore it should check for their presence and exit with an `UNKNOWN`
  if any are missing.