### PR TITLE
Ensure logfile has not expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Usage: ./check_clamav -l <path> [options]
 # exit OK if 0 infected files detected, CRITICAL if 1 or more detected
 ./check_clamav -l /tmp/clamav.log
 
+# exit UNKNOWN if logfile is more than 1 hour old
+./check_clamav -l /tmp/clamav.log -e '1 hour'
+
 # exit OK if 0 infected files detected, WARNING if upto 10 detected, CRITICAL if 10 or more detected
 ./check_clamav -l /tmp/clamav.log -c 10
 
@@ -48,13 +51,15 @@ Usage: ./check_clamav -l <path> [options]
 
 ```
 -l, --logfile <path>        path to clamscan logfile
+-e, --expiry <duration>     expiry threshold for logfile
 -w, --warning <number>      number of infected files treat as WARNING
 -c, --critical <number>     number of infected files to treat as CRITICAL
 -V, --version               output version
 -h, --help                  output help information
 ```
 
-`-c`/`--critical` takes priority over `-w`/`--warning`.
+* `-e`/`--expiry` should be a human readable duration, e.g. '1 hour', or '7 days'.
+* `-c`/`--critical` takes priority over `-w`/`--warning`.
 
 ## Dependencies
 

--- a/check_clamav
+++ b/check_clamav
@@ -15,6 +15,7 @@ CRITICAL=2
 UNKNOWN=3
 CRITICAL_THRESHOLD=1
 WARNING_THRESHOLD=1
+EXPIRY_THRESHOLD='48 hours'
 
 #
 # Output version.
@@ -93,6 +94,36 @@ for dependency in cut grep rev sed; do
   fi
 done
 
+# ensure we have GNU date
+if ! date --version >/dev/null 2>&1 ; then
+  if gdate --version >/dev/null 2>&1 ; then
+    date () { gdate "$@"; }
+  else
+    echo 'UNKNOWN: Unable to find GNU date'
+    exit $UNKNOWN
+  fi
+fi
+
+# ensure we have GNU stat
+if ! stat --version >/dev/null 2>&1 ; then
+  if gstat --version >/dev/null 2>&1 ; then
+    stat () { gstat "$@"; }
+  else
+    echo 'UNKNOWN: Unable to find GNU stat'
+    exit $UNKNOWN
+  fi
+fi
+
+# ensure we have GNU stat
+if ! touch --version >/dev/null 2>&1 ; then
+  if gtouch --version >/dev/null 2>&1 ; then
+    touch () { gtouch "$@"; }
+  else
+    echo 'UNKNOWN: Unable to find GNU touch'
+    exit $UNKNOWN
+  fi
+fi
+
 # ensure we have a LOGFILE_PATH
 if [ -z "$LOGFILE_PATH" ]; then
   echo 'UNKNOWN: --logfile/-l not set'
@@ -116,6 +147,14 @@ fi
 INFECTED_FILES_COUNT=$(echo "$SCAN_SUMMARY" | grep '^Infected files:' | rev | cut -d' ' -f1 | rev)
 if [ -z "$INFECTED_FILES_COUNT" ]; then
   echo 'UNKNOWN: Unable to locate infected files count within scan summary'
+  exit $UNKNOWN
+fi
+
+# ensure the logfile has not expired
+LOGFILE_LAST_MODIFIED_DATE="$(stat --format='%Y' $LOGFILE_PATH)"
+THRESHOLD_DATE="$(date --date="-$EXPIRY_THRESHOLD" +'%s')"
+if [ "$LOGFILE_LAST_MODIFIED_DATE" -lt "$THRESHOLD_DATE" ]; then
+  echo "UNKNOWN: Logfile has expired beyond threshold: ${EXPIRY_THRESHOLD}"
   exit $UNKNOWN
 fi
 

--- a/check_clamav
+++ b/check_clamav
@@ -44,17 +44,21 @@ help() {
   Examples:
     ./check_clamav -l /tmp/clamav.log
 
+    ./check_clamav -l /tmp/clamav.log -e '1 hour'
+
     ./check_clamav -l /tmp/clamav.log -c 10
 
     ./check_clamav -l /tmp/clamav.log -c 10 -w 5
 
   Options:
     -l, --logfile <path>        path to clamscan logfile
+    -e, --expiry <duration>     expiry threshold for logfile
     -w, --warning <number>      number of infected files treat as WARNING
     -c, --critical <number>     number of infected files to treat as CRITICAL
     -V, --version               output version
     -h, --help                  output help information
 
+  -e/--expiry should be a human readable duration, e.g. '1 hour', or '7 days'.
   -c/--critical takes priority over -w/--warning.
 
   For more information, see https://github.com/tommarshall/nagios-check-clamav
@@ -70,6 +74,7 @@ while test $# -ne 0; do
   ARG=$1; shift
   case $ARG in
     -l|--logfile) LOGFILE_PATH=$1; shift ;;
+    -e|--expiry) EXPIRY_THRESHOLD=$1; shift ;;
     -w|--warning) WARNING_THRESHOLD=$1; shift ;;
     -c|--critical) CRITICAL_THRESHOLD=$1; shift ;;
     -V|--version) version; exit ;;
@@ -150,11 +155,16 @@ if [ -z "$INFECTED_FILES_COUNT" ]; then
   exit $UNKNOWN
 fi
 
+# ensure the expiry argument is valid
+if ! THRESHOLD_DATE="$(date --date="-$EXPIRY_THRESHOLD" +'%s' 2>/dev/null)"; then
+  echo "UNKNOWN: Invalid expiry specified: ${EXPIRY_THRESHOLD}"
+  exit $UNKNOWN
+fi
+
 # ensure the logfile has not expired
 LOGFILE_LAST_MODIFIED_DATE="$(stat --format='%Y' $LOGFILE_PATH)"
-THRESHOLD_DATE="$(date --date="-$EXPIRY_THRESHOLD" +'%s')"
 if [ "$LOGFILE_LAST_MODIFIED_DATE" -lt "$THRESHOLD_DATE" ]; then
-  echo "UNKNOWN: Logfile has expired beyond threshold: ${EXPIRY_THRESHOLD}"
+  echo "UNKNOWN: Logfile has expired, more than ${EXPIRY_THRESHOLD} old"
   exit $UNKNOWN
 fi
 

--- a/test/check_clamav.bats
+++ b/test/check_clamav.bats
@@ -106,7 +106,7 @@ EOF
   assert_output "CRITICAL: 1 infected file(s) detected"
 }
 
-@test "exits UNKNOWN logfile older than the threshold" {
+@test "exits UNKNOWN logfile older than the default threshold" {
   cat > clamav.log.clean <<-EOF
 ----------- SCAN SUMMARY -----------
 Known viruses: 6297594
@@ -123,7 +123,7 @@ EOF
   run $BASE_DIR/check_clamav --logfile clamav.log.clean
 
   assert_failure 3
-  assert_output "UNKNOWN: Logfile has expired beyond threshold: 48 hours"
+  assert_output "UNKNOWN: Logfile has expired, more than 48 hours old"
 }
 
 # --logfile
@@ -138,6 +138,60 @@ EOF
 
   assert_success
   assert_output "OK: 0 infected file(s) detected"
+}
+
+# --expiry
+# ------------------------------------------------------------------------------
+@test "--expiry overrides default" {
+  cat > clamav.log.clean <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 0
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+  touch -m -d "$(date -d '-2 hours')" clamav.log.clean
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.clean --expiry '1 hour'
+
+  assert_failure 3
+  assert_output "UNKNOWN: Logfile has expired, more than 1 hour old"
+}
+
+@test "-e is an alias for --expiry" {
+  cat > clamav.log.clean <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 0
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+  touch -m -d "$(date -d '-2 hours')" clamav.log.clean
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.clean -e '1 hour'
+
+  assert_failure 3
+  assert_output "UNKNOWN: Logfile has expired, more than 1 hour old"
+}
+
+@test "exits UNKNOWN if invalid date string" {
+  cat > clamav.log.clean <<-EOF
+----------- SCAN SUMMARY -----------
+Infected files: 0
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.clean --expiry 'not-a-valid-date'
+
+  assert_failure 3
+  assert_output "UNKNOWN: Invalid expiry specified: not-a-valid-date"
 }
 
 # --critical

--- a/test/check_clamav.bats
+++ b/test/check_clamav.bats
@@ -106,6 +106,26 @@ EOF
   assert_output "CRITICAL: 1 infected file(s) detected"
 }
 
+@test "exits UNKNOWN logfile older than the threshold" {
+  cat > clamav.log.clean <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 0
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+  touch -m -d "$(date -d '-49 hours')" clamav.log.clean
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.clean
+
+  assert_failure 3
+  assert_output "UNKNOWN: Logfile has expired beyond threshold: 48 hours"
+}
+
 # --logfile
 # ------------------------------------------------------------------------------
 @test "-l is an alias for --logfile" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -3,6 +3,27 @@
 BASE_DIR=$(dirname $BATS_TEST_DIRNAME)
 TMP_DIRECTORY=$(mktemp -d)
 
+# ensure GNU date
+if ! date --version >/dev/null 2>&1 ; then
+  if gdate --version >/dev/null 2>&1 ; then
+    date () { gdate "$@"; }
+  fi
+fi
+
+# ensure GNU stat
+if ! stat --version >/dev/null 2>&1 ; then
+  if gstat --version >/dev/null 2>&1 ; then
+    stat () { gstat "$@"; }
+  fi
+fi
+
+# ensure GNU stat
+if ! touch --version >/dev/null 2>&1 ; then
+  if gtouch --version >/dev/null 2>&1 ; then
+    touch () { gtouch "$@"; }
+  fi
+fi
+
 setup() {
   cd $TMP_DIRECTORY
 }


### PR DESCRIPTION
**Because:**

* The check is not responsible for generating the logfile, so it's
  possible that the mechanic that is creating the logfile is broken, or
  has stopped.
* The check should therefore ensure that the logfile has been modified
  within a reasonable timeframe.

**This change:**

* Sets the default expiry to 48 hours, assuming the common use case will be at
  least a daily scan, if not more frequent than that.
* Adds a `-e`/`--expiry` arg for overriding the default expiry threshold.
