### PR TITLE
Add -v/--verbose arg to display scan summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Usage: ./check_clamav -l <path> [options]
 -e, --expiry <duration>     expiry threshold for logfile
 -w, --warning <number>      number of infected files treat as WARNING
 -c, --critical <number>     number of infected files to treat as CRITICAL
+-v, --verbose               include the scan summary in the output
 -V, --version               output version
 -h, --help                  output help information
 ```

--- a/check_clamav
+++ b/check_clamav
@@ -16,6 +16,7 @@ UNKNOWN=3
 CRITICAL_THRESHOLD=1
 WARNING_THRESHOLD=1
 EXPIRY_THRESHOLD='48 hours'
+VERBOSE=0
 
 #
 # Output version.
@@ -55,6 +56,7 @@ help() {
     -e, --expiry <duration>     expiry threshold for logfile
     -w, --warning <number>      number of infected files treat as WARNING
     -c, --critical <number>     number of infected files to treat as CRITICAL
+    -v, --verbose               include the scan summary in the output
     -V, --version               output version
     -h, --help                  output help information
 
@@ -64,6 +66,15 @@ help() {
   For more information, see https://github.com/tommarshall/nagios-check-clamav
 
 EOF
+}
+
+#
+# Output nagios report.
+#
+
+report() {
+  echo "$@"
+  test $VERBOSE -eq 1 && echo "${SCAN_SUMMARY}"
 }
 
 #
@@ -77,6 +88,7 @@ while test $# -ne 0; do
     -e|--expiry) EXPIRY_THRESHOLD=$1; shift ;;
     -w|--warning) WARNING_THRESHOLD=$1; shift ;;
     -c|--critical) CRITICAL_THRESHOLD=$1; shift ;;
+    -v|--verbose) VERBOSE=1 ;;
     -V|--version) version; exit ;;
     -h|--help) help; exit ;;
     *)
@@ -174,12 +186,12 @@ fi
 
 if [ "$INFECTED_FILES_COUNT" -lt "$CRITICAL_THRESHOLD" ]; then
   if [ "$INFECTED_FILES_COUNT" -lt "$WARNING_THRESHOLD" ]; then
-    echo "OK: ${INFECTED_FILES_COUNT} infected file(s) detected"
+    report "OK: ${INFECTED_FILES_COUNT} infected file(s) detected"
     exit $OK
   fi
-  echo "WARNING: ${INFECTED_FILES_COUNT} infected file(s) detected"
+  report "WARNING: ${INFECTED_FILES_COUNT} infected file(s) detected"
   exit $WARNING
 fi
 
-echo "CRITICAL: ${INFECTED_FILES_COUNT} infected file(s) detected"
+report "CRITICAL: ${INFECTED_FILES_COUNT} infected file(s) detected"
 exit $CRITICAL

--- a/test/check_clamav.bats
+++ b/test/check_clamav.bats
@@ -297,6 +297,54 @@ EOF
   assert_output "CRITICAL: 2 infected file(s) detected"
 }
 
+# --verbose
+# ------------------------------------------------------------------------------
+@test "--verbose includes the scan summary in the output" {
+  cat > clamav.log <<-EOF
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 0
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log --verbose
+
+  assert_success
+  assert_output <<-EOF
+OK: 0 infected file(s) detected
+----------- SCAN SUMMARY -----------
+Known viruses: 6297594
+Engine version: 0.99.2
+Scanned directories: 1
+Infected files: 0
+Scanned files: 35
+Data scanned: 0.11 MB
+Data read: 0.05 MB (ratio 2.00:1)
+Time: 13.705 sec (0 m 13 s)
+EOF
+}
+
+@test "-v is an alias for --verbose" {
+  cat > clamav.log <<-EOF
+----------- SCAN SUMMARY -----------
+Infected files: 0
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log -v
+
+  assert_success
+  assert_output <<-EOF
+OK: 0 infected file(s) detected
+----------- SCAN SUMMARY -----------
+Infected files: 0
+EOF
+}
+
 # --version
 # ------------------------------------------------------------------------------
 @test "--version prints the version" {


### PR DESCRIPTION
**Because:**

* The scan summary contains useful information about the scan.
* It's too large to include on the one line, and the nagios plugin
  development guidelines state that checks should output oneline, unless
  the `-v`/`--verbose` option is set.