### PR TITLE
Add support for appended logfiles

### DIFF
--- a/check_clamav
+++ b/check_clamav
@@ -78,6 +78,28 @@ report() {
 }
 
 #
+# Extract the last scan summary for the provided logfile path.
+#
+
+extract_summary() {
+  # getting the last occurance with sed alone is actually quite tricky, ref:
+  # https://stackoverflow.com/a/7724969/885540
+  # some sed versions (BSD) don't like semi-colon delimination, ref:
+  # https://stackoverflow.com/a/15470635/885540
+  sed -n '
+    /----------- SCAN SUMMARY -----------/{
+      h
+      b
+    }
+    H
+    ${
+      x
+      p
+    }
+  ' "$1"
+}
+
+#
 # Parse argv.
 #
 
@@ -154,7 +176,7 @@ if ! [[ -f "$LOGFILE_PATH" && -r "$LOGFILE_PATH" ]]; then
 fi
 
 # ensure we're able to locate a scan summary within the logfile
-SCAN_SUMMARY=$(sed -n -e '/----------- SCAN SUMMARY -----------/,$p' $LOGFILE_PATH)
+SCAN_SUMMARY=$(extract_summary $LOGFILE_PATH)
 if [ -z "$SCAN_SUMMARY" ]; then
   echo 'UNKNOWN: Unable to locate scan summary within logfile'
   exit $UNKNOWN

--- a/test/check_clamav.bats
+++ b/test/check_clamav.bats
@@ -126,6 +126,22 @@ EOF
   assert_output "UNKNOWN: Logfile has expired, more than 48 hours old"
 }
 
+@test "uses the last scan summary in the file only" {
+  cat > clamav.log.multiple <<-EOF
+----------- SCAN SUMMARY -----------
+Infected files: 6
+----------- SCAN SUMMARY -----------
+Infected files: 9
+----------- SCAN SUMMARY -----------
+Infected files: 0
+EOF
+
+  run $BASE_DIR/check_clamav --logfile clamav.log.multiple
+
+  assert_success
+  assert_output "OK: 0 infected file(s) detected"
+}
+
 # --logfile
 # ------------------------------------------------------------------------------
 @test "-l is an alias for --logfile" {


### PR DESCRIPTION
**Because:**

* Users may append to the their logfiles rather than replacing them
  after each scan.
* The check should therefore use the last scan summary if multiple are
  present within the logfile.

**Notes:**

* This sed command is pretty barbaric from a complexity/readability
  point of view, but it gets the job done without introducing a further
  dependency. May want to revisit in future.