### PR TITLE
Rename to check_clamav_scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Nagios check_clamav
+# Nagios check_clamav_scan
 
-[![Build Status](https://travis-ci.org/tommarshall/nagios-check-clamav.svg?branch=master)](https://travis-ci.org/tommarshall/nagios-check-clamav)
+[![Build Status](https://travis-ci.org/tommarshall/nagios-check-clamav-scan.svg?branch=master)](https://travis-ci.org/tommarshall/nagios-check-clamav-scan)
 
 Nagios plugin for monitoring [ClamAV] virus scans.
 
@@ -14,37 +14,37 @@ Define a cron task for ClamAV to perform a scan, capturing the output in a logfi
 0 0 * * * root clamscan -r -i /var/www/uploads > /tmp/clamav.log
 ```
 
-Download the [check_clamav] script and make it executable.
+Download the [`check_clamav_scan`] script and make it executable.
 
 Define a new `command` in the Nagios config, e.g.
 
 ```nagios
 define command {
-    command_name    check_clamav
-    command_line    $USER1$/check_clamav -l /tmp/clamav.log
+    command_name    check_clamav_scan
+    command_line    $USER1$/check_clamav_scan -l /tmp/clamav.log
 }
 ```
 
 ## Usage
 
 ```
-Usage: ./check_clamav -l <path> [options]
+Usage: ./check_clamav_scan -l <path> [options]
 ```
 
 ### Examples
 
 ```sh
 # exit OK if 0 infected files detected, CRITICAL if 1 or more detected
-./check_clamav -l /tmp/clamav.log
+./check_clamav_scan -l /tmp/clamav.log
 
 # exit UNKNOWN if logfile is more than 1 hour old
-./check_clamav -l /tmp/clamav.log -e '1 hour'
+./check_clamav_scan -l /tmp/clamav.log -e '1 hour'
 
 # exit OK if 0 infected files detected, WARNING if upto 10 detected, CRITICAL if 10 or more detected
-./check_clamav -l /tmp/clamav.log -c 10
+./check_clamav_scan -l /tmp/clamav.log -c 10
 
 # exit OK if upto 4 infected files detected, WARNING if upto 5 detected, CRITICAL if 10 or more detected
-./check_clamav -l /tmp/clamav.log -c 10 -w 5
+./check_clamav_scan -l /tmp/clamav.log -c 10 -w 5
 ```
 
 ### Options
@@ -68,4 +68,4 @@ Usage: ./check_clamav -l <path> [options]
 * `cut`, `grep`, `rev`, `sed`
 
 [ClamAV]: https://www.clamav.net/
-[check_clamav]: https://cdn.rawgit.com/tommarshall/nagios-check-clamav/v0.1.0/check_clamav
+[check_clamav_scan]: https://cdn.rawgit.com/tommarshall/nagios-check-clamav-scan/v0.1.0/check_clamav_scan

--- a/check_clamav_scan
+++ b/check_clamav_scan
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 #
-# check_clamav - Nagios plugin for monitoring ClamAV.
+# check_clamav_scan - Nagios plugin for monitoring ClamAV.
 #
 # Released under the MIT License.
 #
-# https://github.com/tommarshall/nagios-check-clamav
+# https://github.com/tommarshall/nagios-check-clamav-scan
 #
 
 VERSION=0.1.0
@@ -23,7 +23,7 @@ VERBOSE=0
 #
 
 version() {
-  echo "check_clamav $VERSION"
+  echo "check_clamav_scan $VERSION"
 }
 
 #
@@ -31,7 +31,7 @@ version() {
 #
 
 usage() {
-  echo 'Usage: ./check_clamav -l <path> [options]'
+  echo 'Usage: ./check_clamav_scan -l <path> [options]'
 }
 
 #
@@ -43,13 +43,13 @@ help() {
   cat <<-EOF
 
   Examples:
-    ./check_clamav -l /tmp/clamav.log
+    ./check_clamav_scan -l /tmp/clamav.log
 
-    ./check_clamav -l /tmp/clamav.log -e '1 hour'
+    ./check_clamav_scan -l /tmp/clamav.log -e '1 hour'
 
-    ./check_clamav -l /tmp/clamav.log -c 10
+    ./check_clamav_scan -l /tmp/clamav.log -c 10
 
-    ./check_clamav -l /tmp/clamav.log -c 10 -w 5
+    ./check_clamav_scan -l /tmp/clamav.log -c 10 -w 5
 
   Options:
     -l, --logfile <path>        path to clamscan logfile
@@ -63,7 +63,7 @@ help() {
   -e/--expiry should be a human readable duration, e.g. '1 hour', or '7 days'.
   -c/--critical takes priority over -w/--warning.
 
-  For more information, see https://github.com/tommarshall/nagios-check-clamav
+  For more information, see https://github.com/tommarshall/nagios-check-clamav-scan
 
 EOF
 }

--- a/test/check_clamav_scan.bats
+++ b/test/check_clamav_scan.bats
@@ -7,7 +7,7 @@ load 'test_helper'
 # Validation
 # ------------------------------------------------------------------------------
 @test "exits UNKNOWN if unrecognised option provided" {
-  run $BASE_DIR/check_clamav --logfile /tmp/foo --not-an-arg
+  run $BASE_DIR/check_clamav_scan --logfile /tmp/foo --not-an-arg
 
   assert_failure 3
   assert_line "UNKNOWN: Unrecognised argument: --not-an-arg"
@@ -15,7 +15,7 @@ load 'test_helper'
 }
 
 @test "exits UNKNOWN if --logfile/-l not provided" {
-  run $BASE_DIR/check_clamav
+  run $BASE_DIR/check_clamav_scan
 
   assert_failure 3
   assert_output "UNKNOWN: --logfile/-l not set"
@@ -25,7 +25,7 @@ load 'test_helper'
   touch clamav.log.unreadable
   chmod a-r clamav.log.unreadable
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.unreadable
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.unreadable
 
   assert_failure 3
   assert_output "UNKNOWN: Unable to read logfile: clamav.log.unreadable"
@@ -34,7 +34,7 @@ load 'test_helper'
 @test "exits UNKNOWN if scan summary not found within logfile" {
   touch clamav.log.empty
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.empty
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.empty
 
   assert_failure 3
   assert_output "UNKNOWN: Unable to locate scan summary within logfile"
@@ -52,7 +52,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.partial-summary
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.partial-summary
 
   assert_failure 3
   assert_output "UNKNOWN: Unable to locate infected files count within scan summary"
@@ -60,7 +60,7 @@ EOF
 
 @test "exits UNKNOWN if an executable dependency is missing" {
   PATH='/bin'
-  run $BASE_DIR/check_clamav --logfile clamav.log
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log
 
   assert_failure 3
   assert_output "UNKNOWN: Missing dependency: cut"
@@ -81,7 +81,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.clean
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.clean
 
   assert_success
   assert_output "OK: 0 infected file(s) detected"
@@ -100,7 +100,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.infected
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.infected
 
   assert_failure 2
   assert_output "CRITICAL: 1 infected file(s) detected"
@@ -120,7 +120,7 @@ Time: 13.705 sec (0 m 13 s)
 EOF
   touch -m -d "$(date -d '-49 hours')" clamav.log.clean
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.clean
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.clean
 
   assert_failure 3
   assert_output "UNKNOWN: Logfile has expired, more than 48 hours old"
@@ -136,7 +136,7 @@ Infected files: 9
 Infected files: 0
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.multiple
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.multiple
 
   assert_success
   assert_output "OK: 0 infected file(s) detected"
@@ -150,7 +150,7 @@ EOF
 Infected files: 0
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.clean
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.clean
 
   assert_success
   assert_output "OK: 0 infected file(s) detected"
@@ -172,7 +172,7 @@ Time: 13.705 sec (0 m 13 s)
 EOF
   touch -m -d "$(date -d '-2 hours')" clamav.log.clean
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.clean --expiry '1 hour'
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.clean --expiry '1 hour'
 
   assert_failure 3
   assert_output "UNKNOWN: Logfile has expired, more than 1 hour old"
@@ -192,7 +192,7 @@ Time: 13.705 sec (0 m 13 s)
 EOF
   touch -m -d "$(date -d '-2 hours')" clamav.log.clean
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.clean -e '1 hour'
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.clean -e '1 hour'
 
   assert_failure 3
   assert_output "UNKNOWN: Logfile has expired, more than 1 hour old"
@@ -204,7 +204,7 @@ EOF
 Infected files: 0
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.clean --expiry 'not-a-valid-date'
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.clean --expiry 'not-a-valid-date'
 
   assert_failure 3
   assert_output "UNKNOWN: Invalid expiry specified: not-a-valid-date"
@@ -225,7 +225,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 2
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.infected --critical 2
 
   assert_failure 1
   assert_output "WARNING: 1 infected file(s) detected"
@@ -244,7 +244,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.infected -c 2
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.infected -c 2
 
   assert_failure 1
   assert_output "WARNING: 1 infected file(s) detected"
@@ -265,7 +265,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 3 --warning 2
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.infected --critical 3 --warning 2
 
   assert_success
   assert_output "OK: 1 infected file(s) detected"
@@ -288,7 +288,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 3 -w 2
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.infected --critical 3 -w 2
 
   assert_success
   assert_output "OK: 1 infected file(s) detected"
@@ -307,7 +307,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log.infected --critical 2 --warning 1
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log.infected --critical 2 --warning 1
 
   assert_failure 2
   assert_output "CRITICAL: 2 infected file(s) detected"
@@ -328,7 +328,7 @@ Data read: 0.05 MB (ratio 2.00:1)
 Time: 13.705 sec (0 m 13 s)
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log --verbose
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log --verbose
 
   assert_success
   assert_output <<-EOF
@@ -351,7 +351,7 @@ EOF
 Infected files: 0
 EOF
 
-  run $BASE_DIR/check_clamav --logfile clamav.log -v
+  run $BASE_DIR/check_clamav_scan --logfile clamav.log -v
 
   assert_success
   assert_output <<-EOF
@@ -364,31 +364,31 @@ EOF
 # --version
 # ------------------------------------------------------------------------------
 @test "--version prints the version" {
-  run $BASE_DIR/check_clamav --version
+  run $BASE_DIR/check_clamav_scan --version
 
   assert_success
-  [[ "$output" == "check_clamav "?.?.? ]]
+  [[ "$output" == "check_clamav_scan "?.?.? ]]
 }
 
 @test "-V is an alias for --version" {
-  run $BASE_DIR/check_clamav -V
+  run $BASE_DIR/check_clamav_scan -V
 
   assert_success
-  [[ "$output" == "check_clamav "?.?.? ]]
+  [[ "$output" == "check_clamav_scan "?.?.? ]]
 }
 
 # --help
 # ------------------------------------------------------------------------------
 @test "--help prints the usage" {
-  run $BASE_DIR/check_clamav --help
+  run $BASE_DIR/check_clamav_scan --help
 
   assert_success
-  assert_line --partial "Usage: ./check_clamav -l <path> [options]"
+  assert_line --partial "Usage: ./check_clamav_scan -l <path> [options]"
 }
 
 @test "-h is an alias for --help" {
-  run $BASE_DIR/check_clamav -h
+  run $BASE_DIR/check_clamav_scan -h
 
   assert_success
-  assert_line --partial "Usage: ./check_clamav -l <path> [options]"
+  assert_line --partial "Usage: ./check_clamav_scan -l <path> [options]"
 }


### PR DESCRIPTION
**Because:**

* The scope of this check was originally intended to cover both ClamAV
  scans and ensuring that the ClamAV virus definitions are up to date.
* Although technically possible, combining the two would make both the
  arguments and exit states more complicated.
* It would also cause all scan checks on a machine to fail if the
  signatures are out of date, which would be undesirably repetitive.
* I've therefore taken the view that it's best to reduce the scope of
  this check to the scans only.